### PR TITLE
Got rid of Default handler NSLog warning

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -128,7 +128,7 @@
                 break;
         }
         
-        NSLog(@"Default handler for label: %@, %@, (%d, %d)", linkTypeName, string, range.location, range.length);
+         NSLog(@"Default handler for label: %@, %@, (%lu, %lu)", linkTypeName, string, (unsigned long)range.location, (unsigned long)range.length);
     };
 }
 


### PR DESCRIPTION
Now printing the right format of the variables.
