### PR TITLE
Random crash fix on -attributesFromProperties

### DIFF
--- a/KILabel/Source/KILabel.h
+++ b/KILabel/Source/KILabel.h
@@ -27,6 +27,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class KILabel;
+
+@protocol KILabelDelegate <NSObject>
+
+@optional
+
+- (BOOL)label:(KILabel *)label shouldIgnoreUserHandle:(NSString *)userHandle;
+- (BOOL)label:(KILabel *)label shouldIgnoreHashtag:(NSString *)hashtag;
+- (BOOL)label:(KILabel *)label shouldIgnoreURL:(NSURL *)URL;
+
+
+@end
+
+
 /**
  *  Constants for identifying link types we can detect
  */
@@ -122,6 +136,11 @@ IB_DESIGNABLE
  * @discussion The comparison between the matches and the ignored words is case insensitive.
  */
 @property (nullable, nonatomic, strong) NSSet *ignoredKeywords;
+
+/** 
+ * Optionally, assign a delegate to query for usernames/hashtags/URLs to be ignored
+ */
+@property (nullable, nonatomic, weak) id <KILabelDelegate> delegate;
 
 /** ****************************************************************************************** **
  * @name Format & Appearance

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -420,7 +420,7 @@ NSString * const KILabelLinkKey = @"link";
         NSRange matchRange = [match range];
         NSString *matchString = [text substringWithRange:matchRange];
         
-        if (![self ignoreMatch:matchString])
+        if (![self ignoreMatch:matchString] && ![self shouldIgnoreUserHandle:matchString])
         {
             [rangesForUserHandles addObject:@{KILabelLinkTypeKey : @(KILinkTypeUserHandle),
                                               KILabelRangeKey : [NSValue valueWithRange:matchRange],
@@ -453,7 +453,7 @@ NSString * const KILabelLinkKey = @"link";
         NSRange matchRange = [match range];
         NSString *matchString = [text substringWithRange:matchRange];
         
-        if (![self ignoreMatch:matchString])
+        if (![self ignoreMatch:matchString] && ![self shouldIgnoreHashtag:matchString])
         {
             [rangesForHashtags addObject:@{KILabelLinkTypeKey : @(KILinkTypeHashtag),
                                            KILabelRangeKey : [NSValue valueWithRange:matchRange],
@@ -490,7 +490,7 @@ NSString * const KILabelLinkKey = @"link";
         if (realURL == nil)
             realURL = [plainText substringWithRange:matchRange];
         
-        if (![self ignoreMatch:realURL])
+        if (![self ignoreMatch:realURL] && ![self shouldIgnoreURL:[NSURL URLWithString:realURL]])
         {
             if ([match resultType] == NSTextCheckingTypeLink)
             {
@@ -508,6 +508,27 @@ NSString * const KILabelLinkKey = @"link";
 - (BOOL)ignoreMatch:(NSString*)string
 {
     return [_ignoredKeywords containsObject:[string lowercaseString]];
+}
+
+- (BOOL)shouldIgnoreUserHandle:(NSString *)userHandle {
+    if(self.delegate != nil && [self.delegate respondsToSelector:@selector(label:shouldIgnoreUserHandle:)]) {
+        return [self.delegate label:self shouldIgnoreUserHandle:userHandle];
+    }
+    return NO;
+}
+
+- (BOOL)shouldIgnoreHashtag:(NSString *)hashtag {
+    if(self.delegate != nil && [self.delegate respondsToSelector:@selector(label:shouldIgnoreHashtag:)]) {
+        return [self.delegate label:self shouldIgnoreHashtag:hashtag];
+    }
+    return NO;
+}
+
+- (BOOL)shouldIgnoreURL:(NSURL *)URL {
+    if(self.delegate != nil && [self.delegate respondsToSelector:@selector(label:shouldIgnoreURL:)]) {
+        return [self.delegate label:self shouldIgnoreURL:URL];
+    }
+    return NO;
 }
 
 - (NSAttributedString *)addLinkAttributesToAttributedString:(NSAttributedString *)string linkRanges:(NSArray *)linkRanges

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -704,7 +704,14 @@ NSString * const KILabelLinkKey = @"link";
     if (touchedLink)
     {
         NSRange range = [[touchedLink objectForKey:KILabelRangeKey] rangeValue];
-        NSString *touchedSubstring = [touchedLink objectForKey:KILabelLinkKey];
+        id touchedLinkObject = [touchedLink objectForKey:KILabelLinkKey];
+        NSString *touchedSubstring;
+        if([touchedLinkObject isKindOfClass:[NSURL class]]) {
+            touchedSubstring = [(NSURL *)touchedLinkObject absoluteString];
+        } else {
+            touchedSubstring = touchedLinkObject;
+        }
+
         KILinkType linkType = (KILinkType)[[touchedLink objectForKey:KILabelLinkTypeKey] intValue];
         
         [self receivedActionForLinkType:linkType string:touchedSubstring range:range];

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -353,12 +353,20 @@ NSString * const KILabelLinkKey = @"link";
     paragraph.alignment = self.textAlignment;
     
     // Create the dictionary
-    NSDictionary *attributes = @{NSFontAttributeName : self.font,
-                                 NSForegroundColorAttributeName : color,
-                                 NSShadowAttributeName : shadow,
-                                 NSParagraphStyleAttributeName : paragraph,
-                                 };
-    return attributes;
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    if(self.font != nil) {
+      [attributes setObject:self.font forKey:NSFontAttributeName];
+    }
+    if(color != nil) {
+      [attributes setObject:color forKey:NSForegroundColorAttributeName];
+    }
+    if(shadow != nil) {
+      [attributes setObject:shadow forKey:NSShadowAttributeName];
+    }
+    if(paragraph != nil) {
+      [attributes setObject:paragraph forKey:NSParagraphStyleAttributeName];
+    }
+    return [attributes copy];
 }
 
 /**

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -486,11 +486,10 @@ NSString * const KILabelLinkKey = @"link";
         NSRange matchRange = [match range];
         
         // If there's a link embedded in the attributes, use that instead of the raw text
-        NSString *realURL = [text attribute:NSLinkAttributeName atIndex:matchRange.location effectiveRange:nil];
-        if (realURL == nil)
-            realURL = [plainText substringWithRange:matchRange];
-        
-        if (![self ignoreMatch:realURL] && ![self shouldIgnoreURL:[NSURL URLWithString:realURL]])
+        NSURL *realURL = [text attribute:NSLinkAttributeName atIndex:matchRange.location effectiveRange:nil];
+        NSString *realURLString = realURL == nil ? [plainText substringWithRange:matchRange] : [realURL absoluteString];
+
+        if (![self ignoreMatch:realURLString] && realURL != nil && ![self shouldIgnoreURL:realURL])
         {
             if ([match resultType] == NSTextCheckingTypeLink)
             {


### PR DESCRIPTION
Checks for nil values before constructing and returning the attributes dict
