### PR TITLE
Update regex to handle more cases

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -400,7 +400,7 @@ NSString * const KILabelLinkKey = @"link";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error = nil;
-        regex = [[NSRegularExpression alloc] initWithPattern:@"(?<!\\w)@([\\w\\_]+)?" options:0 error:&error];
+        regex = [[NSRegularExpression alloc] initWithPattern:@"@[\\w-]+" options:0 error:&error];
     });
     
     // Run the expression and get matches
@@ -433,7 +433,7 @@ NSString * const KILabelLinkKey = @"link";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error = nil;
-        regex = [[NSRegularExpression alloc] initWithPattern:@"(?<!\\w)#([\\w\\_]+)?" options:0 error:&error];
+        regex = [[NSRegularExpression alloc] initWithPattern:@"#[\\w-]+" options:0 error:&error];
     });
     
     // Run the expression and get matches


### PR DESCRIPTION
Updating the regex allows handling for the following cases:
- Hashtags/mentions with no spaces in between (#hey#what#are#you#doing)
- Removes colouring when a single # or @ is typed
