### PR TITLE
Return string without @ and # for KILinkTapHandler.

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -701,26 +701,26 @@ NSString * const KILabelLinkKey = @"link";
 {
     switch (linkType)
     {
-    case KILinkTypeUserHandle:
-        if (_userHandleLinkTapHandler)
-        {
-            _userHandleLinkTapHandler(self, string, range);
-        }
-        break;
-        
-    case KILinkTypeHashtag:
-        if (_hashtagLinkTapHandler)
-        {
-            _hashtagLinkTapHandler(self, string, range);
-        }
-        break;
-        
-    case KILinkTypeURL:
-        if (_urlLinkTapHandler)
-        {
-            _urlLinkTapHandler(self, string, range);
-        }
-        break;
+        case KILinkTypeUserHandle:
+            if (_userHandleLinkTapHandler)
+            {
+                _userHandleLinkTapHandler(self, [string substringFromIndex:1], range);
+            }
+            break;
+            
+        case KILinkTypeHashtag:
+            if (_hashtagLinkTapHandler)
+            {
+                _hashtagLinkTapHandler(self, [string substringFromIndex:1], range);
+            }
+            break;
+            
+        case KILinkTypeURL:
+            if (_urlLinkTapHandler)
+            {
+                _urlLinkTapHandler(self, string, range);
+            }
+            break;
     }
 }
 


### PR DESCRIPTION
Hi,

When getting the value of string from KILinkTapHandler, it's easy to delete the @ and # manually in our own apps but I'm thinking that it doesn't makes sense for KILinkTapHandler to return the string value with symbols?

That way, we can immediately use the returned string for our whatever purposes without having to specifically search and remove the symbols.

Its easier to add the symbols with stringWithFormat than to remove them anyway.

What do you think?

Cheers!
