### PR TITLE
regex to not detect hashtag after a character not space

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -433,7 +433,7 @@ NSString * const KILabelLinkKey = @"link";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error = nil;
-        regex = [[NSRegularExpression alloc] initWithPattern:@"(?<!\\w)#([\\w\\_]+)?" options:0 error:&error];
+        regex = [[NSRegularExpression alloc] initWithPattern:@"((#)([\\w\\_]+)?)" options:0 error:&error];
     });
     
     // Run the expression and get matches


### PR DESCRIPTION
I am trying to scan for hashtags from NSStrings in Objective-C and I am using regex.
I made a test status on Facebook / Instagram to see what are the valid hashtags as it is where

Now KILabel.m (getRangeForHashTags line : 437)

regex = [[NSRegularExpression alloc] initWithPattern:@"(?<!\w)#([\w\_]+)?" options:0 error:&error];
My Solution (It's works fine. when not space)

regex = [[NSRegularExpression alloc] initWithPattern:@"((#)([\w\_]+)?)" options:0 error:&error];
Thanks.
