### PR TITLE
bug shadowColor nil

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -334,7 +334,6 @@ NSString * const KILabelLinkKey = @"link";
     else
     {
         shadow.shadowOffset = CGSizeMake(0, -1);
-        shadow.shadowColor = nil;
     }
     
     // Setup color attributes


### PR DESCRIPTION
Error has occurred in that shadowColor of NSShadow becomes nil

Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '**\* -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]

``` objectve-c

@property (nullable, nonatomic, strong) id shadowColor;           // color used for the shadow (default is black with an alpha value of 1/3)

```
