### PR TITLE
Fix issue with indexPath in didSelectRowAtIndexPath when a cell contains KILabel

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -353,11 +353,17 @@ NSString * const KILabelLinkKey = @"link";
     paragraph.alignment = self.textAlignment;
     
     // Create the dictionary
-    NSDictionary *attributes = @{NSFontAttributeName : self.font,
-                                 NSForegroundColorAttributeName : color,
-                                 NSShadowAttributeName : shadow,
-                                 NSParagraphStyleAttributeName : paragraph,
-                                 };
+    NSMutableDictionary *attributes = @{
+        NSFontAttributeName : self.font,
+        NSShadowAttributeName : shadow,
+        NSParagraphStyleAttributeName : paragraph,
+    }.mutableCopy;
+    
+    if (color)
+    {
+        attributes[NSForegroundColorAttributeName] = color;
+    }
+    
     return attributes;
 }
 

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -681,10 +681,6 @@ NSString * const KILabelLinkKey = @"link";
         
         [self receivedActionForLinkType:linkType string:touchedSubstring range:range];
     }
-    else
-    {
-        [super touchesBegan:touches withEvent:event];
-    }
     
     self.selectedRange = NSMakeRange(0, 0);
 }

--- a/KILabelDemo/KILabelDemo/Base.lproj/Main.storyboard
+++ b/KILabelDemo/KILabelDemo/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="GmW-gZ-Ubu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="GmW-gZ-Ubu">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <scenes>
         <!--Label-->
@@ -18,6 +19,7 @@
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is an interactive @label. Tap or hold http://www.google.com and #marvel!" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="9Ku-Sw-eBB" customClass="KILabel">
                                 <rect key="frame" x="20" y="168" width="280" height="61"/>
+                                <animations/>
                                 <gestureRecognizers/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -30,36 +32,42 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pjU-CQ-iBD">
                                 <rect key="frame" x="0.0" y="331" width="320" height="188"/>
                                 <subviews>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detect URLs" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TY6-nI-Q7g">
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Detect URLs" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TY6-nI-Q7g">
                                         <rect key="frame" x="20" y="64" width="98" height="21"/>
+                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detect Hashtags" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TZ-3F-vfa">
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Detect Hashtags" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TZ-3F-vfa">
                                         <rect key="frame" x="20" y="142" width="128" height="21"/>
+                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LnO-YF-SdH">
                                         <rect key="frame" x="251" y="137" width="51" height="31"/>
+                                        <animations/>
                                         <connections>
                                             <action selector="toggleDetectHashtags:" destination="vXZ-lx-hvc" eventType="valueChanged" id="05O-N9-lWs"/>
                                         </connections>
                                     </switch>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oMP-nM-9o0">
                                         <rect key="frame" x="251" y="59" width="51" height="31"/>
+                                        <animations/>
                                         <connections>
                                             <action selector="toggleDetectURLs:" destination="vXZ-lx-hvc" eventType="valueChanged" id="HCx-Qk-Slq"/>
                                         </connections>
                                     </switch>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mHu-Ru-r5S">
                                         <rect key="frame" x="251" y="20" width="51" height="31"/>
+                                        <animations/>
                                         <connections>
                                             <action selector="toggleDetectLinks:" destination="vXZ-lx-hvc" eventType="valueChanged" id="yOv-pU-w7a"/>
                                         </connections>
                                     </switch>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detect Links" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrJ-IY-eO5">
                                         <rect key="frame" x="20" y="25" width="96" height="21"/>
+                                        <animations/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="96" id="K3J-Tn-uSg"/>
                                         </constraints>
@@ -68,16 +76,19 @@
                                     </label>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detect Usernames" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nPx-v0-z26">
                                         <rect key="frame" x="20" y="103" width="143" height="21"/>
+                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7s9-Hr-5Qj">
                                         <rect key="frame" x="251" y="98" width="51" height="31"/>
+                                        <animations/>
                                         <connections>
                                             <action selector="toggleDetectUsernames:" destination="vXZ-lx-hvc" eventType="valueChanged" id="t88-ng-mDG"/>
                                         </connections>
                                     </switch>
                                 </subviews>
+                                <animations/>
                                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstItem="3TZ-3F-vfa" firstAttribute="leading" secondItem="pjU-CQ-iBD" secondAttribute="leading" constant="20" id="0qz-fU-3mc"/>
@@ -100,6 +111,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="9Ku-Sw-eBB" firstAttribute="centerX" secondItem="pjU-CQ-iBD" secondAttribute="centerX" id="FRE-Fp-TWZ"/>
@@ -128,23 +140,28 @@
         <scene sceneID="MTv-c4-KdL">
             <objects>
                 <tableViewController id="Zxq-y8-eM7" customClass="KILabelTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="DSB-ui-meW">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="DSB-ui-meW">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="519"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="labelCell" id="jBo-Gj-Qmp" customClass="KILabelTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="labelCell" id="jBo-Gj-Qmp" customClass="KILabelTableViewCell">
+                                <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jBo-Gj-Qmp" id="b6N-7b-2l0">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JAr-pI-JSD" customClass="KILabel">
                                             <rect key="frame" x="8" y="11" width="304" height="21"/>
+                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="trailing" secondItem="JAr-pI-JSD" secondAttribute="trailing" constant="8" id="Gib-pX-hWL"/>
                                         <constraint firstItem="JAr-pI-JSD" firstAttribute="leading" secondItem="b6N-7b-2l0" secondAttribute="leading" constant="8" id="J6U-kA-p43"/>
@@ -152,6 +169,7 @@
                                         <constraint firstAttribute="bottom" secondItem="JAr-pI-JSD" secondAttribute="bottom" constant="11" id="jmi-Zy-G34"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <animations/>
                                 <connections>
                                     <outlet property="label" destination="JAr-pI-JSD" id="AmK-O8-0uR"/>
                                 </connections>
@@ -177,6 +195,7 @@
                     <nil key="simulatedBottomBarMetrics"/>
                     <tabBar key="tabBar" contentMode="scaleToFill" id="W0i-tW-acY">
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     </tabBar>
                     <connections>
@@ -189,9 +208,4 @@
             <point key="canvasLocation" x="697" y="549"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/KILabelDemo/KILabelDemo/KILabelTableViewController.m
+++ b/KILabelDemo/KILabelDemo/KILabelTableViewController.m
@@ -94,6 +94,11 @@ NSString * const KILabelCellIdentifier = @"labelCell";
     return cell;
 }
 
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSLog(@"Selected row indexPath: %@", indexPath);
+}
+
 /**
  *  Called when a link is tapped.
  *


### PR DESCRIPTION
Related to #30 

It looks like copy-paste issue when a chunk of code at the touchesEnded was copied from touchesBegan and after super's touchesEnded super's touchesBegan is being called.

Main.storyboard was updated to make a cell selectable.
KILabelTableViewController.m updated with logging so you can check issue.

To reproduce the issue revert my changes in KILabel.m and try the following steps:
1) tap first cell - indexPath is 0-0  (correct)
2) tap second cell - indexPath is still 0-0 (wrong)
3) tap second call again - indexPath is 0-1 (correct)
4) tap first cell - indexPath is 0-1 (wrong)
5) tap first cell again - indexPath is 0-0 (correct)

Hope you will check this PR asap because it's very useful pod.

ADDED: fix for the crash caused by adding nil color to a dict
