### PR TITLE
Fix crash

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -353,12 +353,20 @@ NSString * const KILabelLinkKey = @"link";
     paragraph.alignment = self.textAlignment;
     
     // Create the dictionary
-    NSDictionary *attributes = @{NSFontAttributeName : self.font,
-                                 NSForegroundColorAttributeName : color,
-                                 NSShadowAttributeName : shadow,
-                                 NSParagraphStyleAttributeName : paragraph,
-                                 };
-    return attributes;
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    if (self.font != nil) {
+        [attributes setObject:self.font forKey:NSFontAttributeName];
+    }
+    if (color != nil) {
+        [attributes setObject:color forKey:NSForegroundColorAttributeName];
+    }
+    if (shadow != nil) {
+        [attributes setObject:shadow forKey:NSShadowAttributeName];
+    }
+    if (paragraph != nil) {
+        [attributes setObject:paragraph forKey:NSParagraphStyleAttributeName];
+    }
+    return [attributes copy];
 }
 
 /**


### PR DESCRIPTION
This patch fixes a crash by checking nil values.

```
Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 6523146056 __exceptionPreprocess
1  libobjc.A.dylib                6870957952 objc_exception_throw
2  CoreFoundation                 6522025928 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
3  CoreFoundation                 6522025568 +[NSDictionary dictionaryWithObjects:forKeys:count:]
4  KILabel                        4314112932 -[KILabel attributesFromProperties] (KILabel.m:356)
5  KILabel                        4314110664 -[KILabel setText:] (KILabel.m:224)
```
