### PR TITLE
Preserve links already defined in NSAttributedString

### DIFF
--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -493,7 +493,17 @@ NSString * const KILabelLinkKey = @"link";
             }
         }
     }
-    
+	
+	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+		if (value != nil)
+		{
+			[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+								  KILabelRangeKey : [NSValue valueWithRange:range],
+								  KILabelLinkKey : value,
+								   }];
+		}
+	}];
+	
     return rangesForURLs;
 }
 

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -494,13 +494,24 @@ NSString * const KILabelLinkKey = @"link";
         }
     }
 	
-	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id _Nullable value, NSRange range, BOOL * _Nonnull stop) {
 		if (value != nil)
 		{
-			[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
-								  KILabelRangeKey : [NSValue valueWithRange:range],
-								  KILabelLinkKey : value,
-								   }];
+			if ([value class] == [NSURL class])
+			{
+				NSURL *valueURL = (NSURL *) value;
+				[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+									  KILabelRangeKey : [NSValue valueWithRange:range],
+									  KILabelLinkKey : valueURL.absoluteString,
+									   }];
+			}
+			else
+			{
+				[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+										   KILabelRangeKey : [NSValue valueWithRange:range],
+										   KILabelLinkKey : value,
+										   }];
+			}
 		}
 	}];
 	

--- a/KILabelDemo/KILabelDemo/KIViewController.m
+++ b/KILabelDemo/KILabelDemo/KIViewController.m
@@ -51,6 +51,11 @@
     
     _label.systemURLStyle = YES;
 
+	NSMutableAttributedString *string = [_label.attributedText mutableCopy];
+	[string addAttribute:NSLinkAttributeName
+				   value:@"https://www.google.com/search?q=interactive"
+				   range:NSMakeRange(11, 11)];
+	_label.attributedText = string;
     // Attach block for handling taps on usenames
     _label.userHandleLinkTapHandler = ^(KILabel *label, NSString *string, NSRange range) {
         NSString *message = [NSString stringWithFormat:@"You tapped %@", string];


### PR DESCRIPTION
I needed to make sure that if a label already has links defined in its attributed string, those links were preserved. I added an example in the demo app as well.
