### PR TITLE
Preserve links already defined in NSAttributedString

### DIFF
--- a/KILabel.podspec
+++ b/KILabel.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "KILabel"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "Replacement for UILabel for iOS 7 and 8 that provides automatic detection of links such as URLs, twitter style usernames and hashtags."
 
   s.description  = <<-DESC

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -493,7 +493,17 @@ NSString * const KILabelLinkKey = @"link";
             }
         }
     }
-    
+	
+	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+		if (value != nil)
+		{
+			[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+								  KILabelRangeKey : [NSValue valueWithRange:range],
+								  KILabelLinkKey : value,
+								   }];
+		}
+	}];
+	
     return rangesForURLs;
 }
 

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -494,13 +494,24 @@ NSString * const KILabelLinkKey = @"link";
         }
     }
 	
-	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+	[text enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, text.length) options:0 usingBlock:^(id _Nullable value, NSRange range, BOOL * _Nonnull stop) {
 		if (value != nil)
 		{
-			[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
-								  KILabelRangeKey : [NSValue valueWithRange:range],
-								  KILabelLinkKey : value,
-								   }];
+			if ([value class] == [NSURL class])
+			{
+				NSURL *valueURL = (NSURL *) value;
+				[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+									  KILabelRangeKey : [NSValue valueWithRange:range],
+									  KILabelLinkKey : valueURL.absoluteString,
+									   }];
+			}
+			else
+			{
+				[rangesForURLs addObject:@{KILabelLinkTypeKey : @(KILinkTypeURL),
+										   KILabelRangeKey : [NSValue valueWithRange:range],
+										   KILabelLinkKey : value,
+										   }];
+			}
 		}
 	}];
 	

--- a/KILabel/Source/KILabel.m
+++ b/KILabel/Source/KILabel.m
@@ -478,7 +478,12 @@ NSString * const KILabelLinkKey = @"link";
         NSRange matchRange = [match range];
         
         // If there's a link embedded in the attributes, use that instead of the raw text
-        NSString *realURL = [text attribute:NSLinkAttributeName atIndex:matchRange.location effectiveRange:nil];
+        id resultObject = [text attribute:NSLinkAttributeName atIndex:matchRange.location effectiveRange:nil];
+		NSString *realURL = resultObject;
+		if ([resultObject respondsToSelector: @selector(absoluteString)])
+		{
+			realURL = [resultObject absoluteString];
+		}
         if (realURL == nil)
             realURL = [plainText substringWithRange:matchRange];
         

--- a/KILabelDemo/KILabelDemo/KIViewController.m
+++ b/KILabelDemo/KILabelDemo/KIViewController.m
@@ -51,6 +51,11 @@
     
     _label.systemURLStyle = YES;
 
+	NSMutableAttributedString *string = [_label.attributedText mutableCopy];
+	[string addAttribute:NSLinkAttributeName
+				   value:@"https://www.google.com/search?q=interactive"
+				   range:NSMakeRange(11, 11)];
+	_label.attributedText = string;
     // Attach block for handling taps on usenames
     _label.userHandleLinkTapHandler = ^(KILabel *label, NSString *string, NSRange range) {
         NSString *message = [NSString stringWithFormat:@"You tapped %@", string];


### PR DESCRIPTION
Previous pull request had support only for strings as NSLinkAttributeName values. This one also has NSURL's (as the documentation states should be allowed)
